### PR TITLE
fix-examples: Fix crash in examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,11 @@ endif ()
 option(HDF4CPP_BUILD_TESTS "Enable building tests" ON)
 option(HDF4CPP_BUILD_EXAMPLES "Enable building examples" ON)
 
+if (NOT DEFINED TEST_DATA_PATH)
+    set(TEST_DATA_PATH "${PROJECT_SOURCE_DIR}/tests/test_data/")
+    message(STATUS "No path to test data defined, using ${TEST_DATA_PATH} as default")
+endif ()
+
 if (HDF4CPP_BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,11 +19,6 @@ target_compile_definitions(hdf4cpp-tests PRIVATE
         GTEST_DONT_DEFINE_FAIL
         GTEST_DONT_DEFINE_SUCCEED)
 
-
-if (NOT DEFINED TEST_DATA_PATH)
-    set(TEST_DATA_PATH "${PROJECT_SOURCE_DIR}/tests/test_data/")
-    message(STATUS "No path to test data defined, using ${TEST_DATA_PATH} as default")
-endif ()
 target_compile_definitions(hdf4cpp-tests PRIVATE
         "TEST_DATA_PATH=\"${TEST_DATA_PATH}\"")
 


### PR DESCRIPTION
This fixes:
> $ examples/example_vdata
> terminate called after throwing an instance of 'hdf4cpp::HdfException'
>  what():  HDF4CPP: cannot construct object, the id is invalid
> [1]    29130 abort (core dumped)  examples/example_vdata

This was caused by an unset TEST_DATA_PATH variable. It was only set
in the tests directory, which did not propagate to the examples directory.